### PR TITLE
Payments

### DIFF
--- a/app/controllers/api/v1/users/payments_controller.rb
+++ b/app/controllers/api/v1/users/payments_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    module Users
+      class PaymentsController < ApplicationController
+        def create
+          PaymentCreationService.new(current_user).create!(payment_params)
+          head :no_content
+        end
+
+        private
+
+        def payment_params
+          params.require(:payment).permit(:friend_id, :amount, :description)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::API
   rescue_from ActionController::ParameterMissing,  with: :render_parameter_missing
   rescue_from ActiveRecord::RecordInvalid,         with: :render_record_invalid
   rescue_from ActiveRecord::RecordNotFound,        with: :render_not_found
+  rescue_from VenmoApiError,                       with: :render_venmo_error
 
   private
 
@@ -36,6 +37,12 @@ class ApplicationController < ActionController::API
     logger.info(exception)
     render json: json_error(exception, I18n.t('api.errors.not_found')),
            status: :not_found
+  end
+
+  def render_venmo_error(exception)
+    logger.info(exception)
+    render json: json_error(exception, I18n.t('errors.title')),
+           status: :bad_request
   end
 
   def json_error(exception, title)

--- a/app/errors/payments/no_friends_error.rb
+++ b/app/errors/payments/no_friends_error.rb
@@ -1,0 +1,7 @@
+module Payments
+  class NoFriendsError < VenmoApiError
+    def initialize(msg = I18n.t('errors.payment.no_friends'))
+      super
+    end
+  end
+end

--- a/app/errors/venmo_api_error.rb
+++ b/app/errors/venmo_api_error.rb
@@ -1,0 +1,2 @@
+class VenmoApiError < StandardError
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,16 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  content    :text             default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Event < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: payments
+#
+#  id             :integer          not null, primary key
+#  sender_id      :integer
+#  receiver_id    :integer
+#  sender_email   :string           not null
+#  receiver_email :string           not null
+#  amount         :float            default("0.0"), not null
+#  description    :text             default(""), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
+class Payment < ApplicationRecord
+  belongs_to :sender, class_name: 'User'
+  belongs_to :receiver, class_name: 'User'
+
+  validates :amount, presence: true, numericality: { greater_than: 0, less_than: 1_000 }
+  validates :sender_email, :receiver_email, presence: true
+
+  before_validation :init_user_emails, on: :create
+
+  private
+
+  def init_user_emails
+    self.sender_email = sender&.email
+    self.receiver_email = receiver&.email
+  end
+end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -17,6 +17,9 @@ class Payment < ApplicationRecord
   belongs_to :sender, class_name: 'User'
   belongs_to :receiver, class_name: 'User'
 
+  delegate :name, to: :sender, prefix: true
+  delegate :name, to: :receiver, prefix: true
+
   validates :amount, presence: true, numericality: { greater_than: 0, less_than: 1_000 }
   validates :sender_email, :receiver_email, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,15 @@ class User < ApplicationRecord
   has_many :outgoing_friends, through: :outgoing_friendships, source: :friend
   has_many :incoming_friends, through: :incoming_friendships, source: :user
 
+  has_many :received_payments, -> { where(receiver: user) },
+           class_name: 'Payment',
+           dependent: :nullify,
+           inverse_of: :receiver
+  has_many :sent_payments, -> { where(sender: user) },
+           class_name: 'Payment',
+           dependent: :nullify,
+           inverse_of: :sender
+
   validates :name, presence: true
   validates :email, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/services/event_register_service.rb
+++ b/app/services/event_register_service.rb
@@ -1,0 +1,14 @@
+class EventRegisterService
+  def by_payment!(payment)
+    Event.create!(
+      user: payment.sender,
+      content: I18n.t(
+        'model.event.by_payment',
+        sender: payment.sender_name,
+        receiver: payment.receiver_name,
+        date: I18n.l(payment.created_at, format: :short),
+        description: payment.description
+      )
+    )
+  end
+end

--- a/app/services/payment_creation_service.rb
+++ b/app/services/payment_creation_service.rb
@@ -1,0 +1,30 @@
+class PaymentCreationService
+  attr_accessor :user, :params
+
+  def initialize(user)
+    @user = user
+  end
+
+  def create!(params)
+    @params = params
+
+    validate!
+
+    Payment.create!(
+      sender: user,
+      receiver: friend,
+      amount: params[:amount],
+      description: params[:description] || ''
+    )
+  end
+
+  private
+
+  def validate!
+    raise Payments::NoFriendsError unless user.friends.include?(friend)
+  end
+
+  def friend
+    @friend ||= User.find(params[:friend_id])
+  end
+end

--- a/app/services/payment_creation_service.rb
+++ b/app/services/payment_creation_service.rb
@@ -10,12 +10,10 @@ class PaymentCreationService
 
     validate!
 
-    Payment.create!(
-      sender: user,
-      receiver: friend,
-      amount: params[:amount],
-      description: params[:description] || ''
-    )
+    ActiveRecord::Base.transaction do
+      payment = create_payment
+      EventRegisterService.new.by_payment!(payment)
+    end
   end
 
   private
@@ -26,5 +24,14 @@ class PaymentCreationService
 
   def friend
     @friend ||= User.find(params[:friend_id])
+  end
+
+  def create_payment
+    Payment.create!(
+      sender: user,
+      receiver: friend,
+      amount: params[:amount],
+      description: params[:description] || ''
+    )
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
     friendship:
       error:
         already_exist: 'The frienship already exists'
+    event:
+      by_payment: '%{sender} paid %{receiver} on %{date} - %{description}'
   errors:
     title: 'Something went wrong'
     payment:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,3 +40,7 @@ en:
     friendship:
       error:
         already_exist: 'The frienship already exists'
+  errors:
+    title: 'Something went wrong'
+    payment:
+      no_friends: 'You must be friend to send payments'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[show create] do
         scope module: :users do
           resources :friendships, only: :create
+          resources :payments, only: :create
         end
       end
     end

--- a/db/migrate/20201008031209_create_payments.rb
+++ b/db/migrate/20201008031209_create_payments.rb
@@ -1,0 +1,13 @@
+class CreatePayments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :payments do |t|
+      t.belongs_to :sender, class_name: 'User'
+      t.belongs_to :receiver, class_name: 'User'
+      t.string :sender_email, null: false
+      t.string :receiver_email, null: false
+      t.float :amount, null: false, default: 0
+      t.text :description, null: false, default: ''
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201009034950_create_events.rb
+++ b/db/migrate/20201009034950_create_events.rb
@@ -1,0 +1,9 @@
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.belongs_to :user
+      t.text :content, null: false, default: ''
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_031209) do
+ActiveRecord::Schema.define(version: 2020_10_09_034950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "user_id"
+    t.text "content", default: "", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_events_on_user_id"
+  end
 
   create_table "friendships", force: :cascade do |t|
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_195955) do
+ActiveRecord::Schema.define(version: 2020_10_08_031209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,19 @@ ActiveRecord::Schema.define(version: 2020_10_07_195955) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["friend_id"], name: "index_friendships_on_friend_id"
     t.index ["user_id"], name: "index_friendships_on_user_id"
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.bigint "sender_id"
+    t.bigint "receiver_id"
+    t.string "sender_email", null: false
+    t.string "receiver_email", null: false
+    t.float "amount", default: 0.0, null: false
+    t.text "description", default: "", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["receiver_id"], name: "index_payments_on_receiver_id"
+    t.index ["sender_id"], name: "index_payments_on_sender_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  content    :text             default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :event do
+    user
+    content { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
   factory :payment do
     sender
     receiver
-    amount      { Faker::Number.between(from: 0.1, to: 999.99) }
+    amount      { Faker::Number.between(from: 0.1, to: 999.99).round(2) }
     description { Faker::Lorem.paragraph }
   end
 end

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: payments
+#
+#  id             :integer          not null, primary key
+#  sender_id      :integer
+#  receiver_id    :integer
+#  sender_email   :string           not null
+#  receiver_email :string           not null
+#  amount         :float            default("0.0"), not null
+#  description    :text             default(""), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
+FactoryBot.define do
+  factory :payment do
+    sender
+    receiver
+    amount      { Faker::Number.between(from: 0.1, to: 999.99) }
+    description { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -10,7 +10,7 @@
 #
 
 FactoryBot.define do
-  factory :user, aliases: [:friend] do
+  factory :user, aliases: %i[friend sender receiver] do
     email { Faker::Internet.unique.email }
     name  { Faker::Name.name }
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: events
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  content    :text             default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:content) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: payments
+#
+#  id             :integer          not null, primary key
+#  sender_id      :integer
+#  receiver_id    :integer
+#  sender_email   :string           not null
+#  receiver_email :string           not null
+#  amount         :float            default("0.0"), not null
+#  description    :text             default(""), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:sender_email) }
+    it { is_expected.to validate_presence_of(:receiver_email) }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than(0).is_less_than(1_000) }
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:sender).class_name('User') }
+    it { is_expected.to belong_to(:receiver).class_name('User') }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe User, type: :model do
       is_expected.to have_many(:incoming_friends).through(:incoming_friendships)
                                                  .source(:user)
     }
+    it {
+      is_expected.to have_many(:received_payments).class_name('Payment')
+                                                  .dependent(:nullify)
+                                                  .inverse_of(:receiver)
+    }
+    it {
+      is_expected.to have_many(:sent_payments).class_name('Payment')
+                                              .dependent(:nullify)
+                                              .inverse_of(:sender)
+    }
   end
 
   describe '#friends' do

--- a/spec/requests/api/v1/users/payments/create_spec.rb
+++ b/spec/requests/api/v1/users/payments/create_spec.rb
@@ -35,6 +35,21 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
         )
       end
 
+      it 'creates a new event' do
+        expect { send_payment }.to change(Event, :count).by(1)
+      end
+
+      it 'matches event attributes' do
+        send_payment
+        event = Event.last
+        expect(event.to_json).to include_json(
+          user_id: user.id,
+          content: "#{user.name} paid #{friend.name} on"\
+                   " #{event.created_at.strftime('%d %b %H:%M')} " \
+                   "- #{params[:payment][:description]}"
+        )
+      end
+
       context 'when the params are inverted' do
         let(:user_id) { friend.id }
         let(:friend_id) { user.id }
@@ -59,6 +74,21 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
             description: params[:payment][:description]
           )
         end
+
+        it 'creates a new event' do
+          expect { send_payment }.to change(Event, :count).by(1)
+        end
+
+        it 'matches event attributes' do
+          send_payment
+          event = Event.last
+          expect(event.to_json).to include_json(
+            user_id: friend.id,
+            content: "#{friend.name} paid #{user.name} on"\
+                     " #{event.created_at.strftime('%d %b %H:%M')} " \
+                     "- #{params[:payment][:description]}"
+          )
+        end
       end
     end
 
@@ -78,6 +108,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
           error: 'Something went wrong',
           detail: 'You must be friend to send payments'
         )
+      end
+
+      it 'does not create a new event' do
+        expect { send_payment }.not_to change(Event, :count)
       end
     end
   end
@@ -105,6 +139,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
           error: 'A required param is missing'
         )
       end
+
+      it 'does not create a new event' do
+        expect { send_payment }.not_to change(Event, :count)
+      end
     end
 
     context 'when missing friend id' do
@@ -124,6 +162,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
         expect(response.parsed_body).to include_json(
           error: "Couldn't find the record"
         )
+      end
+
+      it 'does not create a new event' do
+        expect { send_payment }.not_to change(Event, :count)
       end
     end
 
@@ -156,6 +198,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
             }
           )
         end
+
+        it 'does not create a new event' do
+          expect { send_payment }.not_to change(Event, :count)
+        end
       end
 
       context 'when amount is less or equal than 0' do
@@ -178,6 +224,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
               amount: contain_exactly('must be greater than 0')
             }
           )
+        end
+
+        it 'does not create a new event' do
+          expect { send_payment }.not_to change(Event, :count)
         end
       end
 
@@ -202,6 +252,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
             }
           )
         end
+
+        it 'does not create a new event' do
+          expect { send_payment }.not_to change(Event, :count)
+        end
       end
     end
 
@@ -220,6 +274,10 @@ describe 'POST /api/v1/users/:user_id/payments', type: :request do
 
       it 'creates a new payment' do
         expect { send_payment }.to change(Payment, :count).by(1)
+      end
+
+      it 'creates a new event' do
+        expect { send_payment }.to change(Event, :count).by(1)
       end
     end
   end

--- a/spec/requests/api/v1/users/payments/create_spec.rb
+++ b/spec/requests/api/v1/users/payments/create_spec.rb
@@ -1,0 +1,226 @@
+require 'rails_helper'
+
+describe 'POST /api/v1/users/:user_id/payments', type: :request do
+  let!(:user) { create(:user) }
+  let!(:friend) { create(:user) }
+
+  subject(:send_payment) { post api_v1_user_payments_path(user_id), params: params }
+
+  context 'when params are right' do
+    let(:user_id) { user.id }
+    let(:friend_id) { friend.id }
+    let(:params) { { payment: attributes_for(:payment).merge(friend_id: friend_id) } }
+
+    context 'when the friendship exists' do
+      let!(:friendship) { create(:friendship, user: user, friend: friend) }
+
+      it 'returns a successful response' do
+        send_payment
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'creates a new payment' do
+        expect { send_payment }.to change(Payment, :count).by(1)
+      end
+
+      it 'matches payment attributes' do
+        send_payment
+        expect(Payment.last.to_json).to include_json(
+          sender_id: user.id,
+          receiver_id: friend.id,
+          sender_email: user.email,
+          receiver_email: friend.email,
+          amount: params[:payment][:amount],
+          description: params[:payment][:description]
+        )
+      end
+
+      context 'when the params are inverted' do
+        let(:user_id) { friend.id }
+        let(:friend_id) { user.id }
+
+        it 'returns a successful response' do
+          send_payment
+          expect(response).to have_http_status(:no_content)
+        end
+
+        it 'creates a new payment' do
+          expect { send_payment }.to change(Payment, :count).by(1)
+        end
+
+        it 'matches payment attributes' do
+          send_payment
+          expect(Payment.last.to_json).to include_json(
+            sender_id: friend.id,
+            receiver_id: user.id,
+            sender_email: friend.email,
+            receiver_email: user.email,
+            amount: params[:payment][:amount],
+            description: params[:payment][:description]
+          )
+        end
+      end
+    end
+
+    context 'when the friendship does not exist' do
+      it 'returns a failure response' do
+        send_payment
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create a new payment' do
+        expect { send_payment }.not_to change(Payment, :count)
+      end
+
+      it 'returns an error message' do
+        send_payment
+        expect(response.parsed_body).to include_json(
+          error: 'Something went wrong',
+          detail: 'You must be friend to send payments'
+        )
+      end
+    end
+  end
+
+  context 'when some params are not right' do
+    let(:user_id) { user.id }
+    let(:friend_id) { friend.id }
+    let(:params) { { payment: attributes_for(:payment).merge(friend_id: friend_id) } }
+
+    context 'when missing payment' do
+      let(:params) { attributes_for(:payment) }
+
+      it 'returns a failure response' do
+        send_payment
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not create a new payment' do
+        expect { send_payment }.not_to change(Payment, :count)
+      end
+
+      it 'returns an error message' do
+        send_payment
+        expect(response.parsed_body).to include_json(
+          error: 'A required param is missing'
+        )
+      end
+    end
+
+    context 'when missing friend id' do
+      let(:friend_id) { nil }
+
+      it 'returns a failure response' do
+        send_payment
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'does not create a new payment' do
+        expect { send_payment }.not_to change(Payment, :count)
+      end
+
+      it 'returns an error message' do
+        send_payment
+        expect(response.parsed_body).to include_json(
+          error: "Couldn't find the record"
+        )
+      end
+    end
+
+    context 'when amount is not right' do
+      let!(:friendship) { create(:friendship, user: user, friend: friend) }
+      let(:params) do
+        {
+          payment: attributes_for(:payment, amount: amount).merge(friend_id: friend_id)
+        }
+      end
+
+      context 'when missing amount' do
+        let(:amount) { nil }
+
+        it 'returns a failure response' do
+          send_payment
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'does not create a new payment' do
+          expect { send_payment }.not_to change(Payment, :count)
+        end
+
+        it 'returns an error message' do
+          send_payment
+          expect(response.parsed_body).to include_json(
+            errors:
+            {
+              amount: include("can't be blank")
+            }
+          )
+        end
+      end
+
+      context 'when amount is less or equal than 0' do
+        let(:amount) { 0 }
+
+        it 'returns a failure response' do
+          send_payment
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'does not create a new payment' do
+          expect { send_payment }.not_to change(Payment, :count)
+        end
+
+        it 'returns an error message' do
+          send_payment
+          expect(response.parsed_body).to include_json(
+            errors:
+            {
+              amount: contain_exactly('must be greater than 0')
+            }
+          )
+        end
+      end
+
+      context 'when amount is greater or equal than 1000' do
+        let(:amount) { 1_000 }
+
+        it 'returns a failure response' do
+          send_payment
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'does not create a new payment' do
+          expect { send_payment }.not_to change(Payment, :count)
+        end
+
+        it 'returns an error message' do
+          send_payment
+          expect(response.parsed_body).to include_json(
+            errors:
+            {
+              amount: contain_exactly('must be less than 1000')
+            }
+          )
+        end
+      end
+    end
+
+    context 'when missing description' do
+      let!(:friendship) { create(:friendship, user: user, friend: friend) }
+      let(:params) do
+        {
+          payment: attributes_for(:payment, description: nil).merge(friend_id: friend_id)
+        }
+      end
+
+      it 'returns a successful response' do
+        send_payment
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'creates a new payment' do
+        expect { send_payment }.to change(Payment, :count).by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The following changes add the *Payment* model. It is in charge of tracking the money exchanges through Venmo. The model has references to the users who send and receive the payment. Also, I replicate the user's email in the payment model because if it is requested that a user must be deleted from the platform, the payments registry should keep consistency along the time.
