### PR TITLE
User feed

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class UsersController < ApplicationController
+      include Pagy::Backend
+
       def show; end
 
       def create
@@ -8,10 +10,20 @@ module Api
         render :show
       end
 
+      def feed
+        query = Event.where(user_id: current_user.contacts_for_feed).order(created_at: :desc)
+        pagy, @events = pagy(query, page: page)
+        @metadata = pagy_metadata(pagy)
+      end
+
       private
 
       def user_params
         params.require(:user).permit(:email, :name)
+      end
+
+      def page
+        params[:page] || 1
       end
     end
   end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -15,6 +15,10 @@ class Friendship < ApplicationRecord
 
   validate :friendship_already_exists, on: :create
 
+  scope :friendships_of, lambda { |user|
+    where(user: user).or(where(friend: user))
+  }
+
   private
 
   def friendship_already_exists

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,13 @@ class User < ApplicationRecord
   def friends
     incoming_friends + outgoing_friends
   end
+
+  def contacts_for_feed
+    contacts = [id]
+    contacts += friends.pluck(:id)
+    Friendship.friendships_of(contacts)
+              .pluck(:user_id, :friend_id)
+              .flatten
+              .uniq
+  end
 end

--- a/app/views/api/v1/events/_info.json.jbuilder
+++ b/app/views/api/v1/events/_info.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! event, :content, :created_at

--- a/app/views/api/v1/users/feed.json.jbuilder
+++ b/app/views/api/v1/users/feed.json.jbuilder
@@ -1,0 +1,2 @@
+json.events @events, partial: 'api/v1/events/info', as: :event
+json.pagy   @metadata

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,158 @@
+# Pagy initializer file (3.8.3)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+# Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+Pagy::VARS[:metadata] = %i[count page items pages]
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+Pagy::VARS[:items] = 10
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1, defaults: { format: :json } do
       resources :users, only: %i[show create] do
+        member do
+          get :feed
+        end
+
         scope module: :users do
           resources :friendships, only: :create
           resources :payments, only: :create

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
   factory :event do
     user
     content { Faker::Lorem.paragraph }
+
+    trait :with_fake_created_at do
+      created_at { Faker::Date.backward }
+    end
   end
 end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -69,4 +69,53 @@ RSpec.describe Friendship, type: :model do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:friend).class_name('User') }
   end
+
+  describe '.friendship_of' do
+    let!(:user) { create(:user) }
+    let!(:friend_1) { create(:user) }
+    let!(:friend_2) { create(:user) }
+    let!(:no_friend) { create(:user) }
+    let!(:user_friendships) do
+      [
+        create(:friendship, user: user, friend: friend_1),
+        create(:friendship, user: friend_2, friend: user)
+      ]
+    end
+    let!(:no_user_friendships) do
+      [
+        create(:friendship, user: no_friend, friend: friend_1),
+        create(:friendship, user: friend_2, friend: no_friend)
+      ]
+    end
+
+    subject { described_class.friendships_of(user) }
+
+    it 'includes friendship between user and their friends' do
+      expect(subject).to match_array(user_friendships)
+    end
+
+    it 'does not include friendship between their friends and another user' do
+      expect(subject).not_to match_array(no_user_friendships)
+    end
+
+    context 'when provides an array of user‘s id' do
+      let!(:user_2) { create(:user) }
+      let!(:user_2_friendships) do
+        [
+          create(:friendship, user: user_2, friend: friend_1),
+          create(:friendship, user: friend_2, friend: user_2)
+        ]
+      end
+
+      subject { described_class.friendships_of([user.id, user_2.id]) }
+
+      it 'includes friendship between users and their friends' do
+        expect(subject).to match_array(user_friendships + user_2_friendships)
+      end
+
+      it 'does not include friendship between their friends and another user' do
+        expect(subject).not_to match_array(no_user_friendships)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,4 +80,44 @@ RSpec.describe User, type: :model do
       expect(subject).not_to contain_exactly(no_friend)
     end
   end
+
+  describe '#contacts_for_feed' do
+    let!(:user) { create(:user) }
+    let!(:friend) { create(:user) }
+    let!(:friend_2) { create(:user) }
+    let!(:second_level_friend) { create(:user) }
+    let!(:second_level_friend_2) { create(:user) }
+    let!(:no_friend) { create(:user) }
+    let!(:no_friend_2) { create(:user) }
+    let!(:user_friendships) do
+      [
+        create(:friendship, user: user, friend: friend),
+        create(:friendship, user: friend_2, friend: user),
+        create(:friendship, user: friend, friend: second_level_friend),
+        create(:friendship, user: second_level_friend_2, friend: friend_2)
+      ]
+    end
+    let!(:user_no_friendships) do
+      [
+        create(:friendship, user: second_level_friend, friend: no_friend),
+        create(:friendship, user: no_friend_2, friend: second_level_friend_2)
+      ]
+    end
+
+    subject { user.contacts_for_feed }
+
+    it 'contains user contact user‘s id' do
+      expect(subject).to contain_exactly(
+        user.id,
+        friend.id,
+        friend_2.id,
+        second_level_friend.id,
+        second_level_friend_2.id
+      )
+    end
+
+    it 'does not contain no friends users' do
+      expect(subject).not_to contain_exactly(no_friend.id, no_friend_2.id)
+    end
+  end
 end

--- a/spec/requests/api/v1/users/feed_spec.rb
+++ b/spec/requests/api/v1/users/feed_spec.rb
@@ -1,0 +1,232 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/users/:id/feed', type: :request do
+  let!(:user) { create(:user) }
+  let!(:first_level_friend) { create(:user) }
+  let!(:second_level_friend) { create(:user) }
+  let!(:no_friend) { create(:user) }
+  let!(:first_level_friendship) do
+    create(:friendship, user: user, friend: first_level_friend)
+  end
+  let!(:second_level_friendship) do
+    create(:friendship, user: first_level_friend, friend: second_level_friend)
+  end
+  let!(:strange_friendship) do
+    create(:friendship, user: second_level_friend, friend: no_friend)
+  end
+  let(:params) { {} }
+
+  subject(:get_feed) { get feed_api_v1_user_path(user.id), params: params }
+
+  context 'when only exists user events' do
+    let!(:events) do
+      [
+        create(:event, user: user, created_at: Time.zone.today),
+        create(:event, user: user, created_at: 1.day.ago),
+        create(:event, user: user, created_at: 2.days.ago),
+        create(:event, user: user, created_at: 3.days.ago)
+      ]
+    end
+
+    it 'returns a successful response' do
+      get_feed
+      expect(response).to be_successful
+    end
+
+    it 'returns events info ordered by creation date descending' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        events: events.map do |event|
+          {
+            content: event.content,
+            created_at: event.created_at.iso8601(3)
+          }
+        end
+      )
+    end
+
+    it 'returns pagination info' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        pagy: {
+          count: events.size,
+          page: 1,
+          items: events.size,
+          pages: 1
+        }
+      )
+    end
+  end
+
+  context 'when exists first level friend and user events' do
+    let!(:events) do
+      [
+        create(:event, user: user, created_at: Time.zone.today),
+        create(:event, user: first_level_friend, created_at: 1.day.ago),
+        create(:event, user: user, created_at: 2.days.ago),
+        create(:event, user: first_level_friend, created_at: 3.days.ago)
+      ]
+    end
+
+    it 'returns a successful response' do
+      get_feed
+      expect(response).to be_successful
+    end
+
+    it 'returns events info ordered by creation date descending' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        events: events.map do |event|
+          {
+            content: event.content,
+            created_at: event.created_at.iso8601(3)
+          }
+        end
+      )
+    end
+  end
+
+  context 'when exists first and second level friend and user events' do
+    let!(:events) do
+      [
+        create(:event, user: first_level_friend, created_at: Time.zone.today),
+        create(:event, user: user, created_at: 1.day.ago),
+        create(:event, user: second_level_friend, created_at: 2.days.ago),
+        create(:event, user: second_level_friend, created_at: 3.days.ago),
+        create(:event, user: user, created_at: 4.days.ago),
+        create(:event, user: first_level_friend, created_at: 5.days.ago)
+      ]
+    end
+
+    it 'returns a successful response' do
+      get_feed
+      expect(response).to be_successful
+    end
+
+    it 'returns events info ordered by creation date descending' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        events: events.map do |event|
+          {
+            content: event.content,
+            created_at: event.created_at.iso8601(3)
+          }
+        end
+      )
+    end
+  end
+
+  context 'when exists friends, user and no friend events' do
+    let!(:events) do
+      [
+        create(:event, user: first_level_friend, created_at: Time.zone.today),
+        create(:event, user: user, created_at: 1.day.ago),
+        create(:event, user: second_level_friend, created_at: 2.days.ago),
+        create(:event, user: second_level_friend, created_at: 3.days.ago),
+        create(:event, user: user, created_at: 4.days.ago),
+        create(:event, user: first_level_friend, created_at: 5.days.ago)
+      ]
+    end
+    let!(:hidden_event) { create_list(:event, 2, user: no_friend) }
+
+    it 'returns a successful response' do
+      get_feed
+      expect(response).to be_successful
+    end
+
+    it 'returns only friend‘s events info ordered by creation date descending' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        events: events.map do |event|
+          {
+            content: event.content,
+            created_at: event.created_at.iso8601(3)
+          }
+        end
+      )
+    end
+
+    it 'does not returns no-friend‘s events info' do
+      get_feed
+      expect(response.parsed_body).not_to include_json(
+        events: hidden_event.map do |event|
+          {
+            content: event.content,
+            created_at: event.created_at.iso8601(3)
+          }
+        end
+      )
+    end
+  end
+
+  context 'when there are more than 10 events' do
+    let(:event_count) { 15 }
+    let!(:events) { create_list(:event, event_count, :with_fake_created_at, user: user) }
+
+    it 'returns a successful response' do
+      get_feed
+      expect(response).to be_successful
+    end
+
+    it 'returns first 10 events info ordered by creation date descending' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        events: events.sort_by { |event| -event.created_at.to_i }
+                      .first(10)
+                      .map do |event|
+                        {
+                          content: event.content,
+                          created_at: event.created_at.iso8601(3)
+                        }
+                      end
+      )
+    end
+
+    it 'returns pagination info' do
+      get_feed
+      expect(response.parsed_body).to include_json(
+        pagy: {
+          count: event_count,
+          page: 1,
+          items: 10,
+          pages: 2
+        }
+      )
+    end
+
+    context 'when sets the page param' do
+      let(:params) { { page: 2 } }
+
+      it 'returns a successful response' do
+        get_feed
+        expect(response).to be_successful
+      end
+
+      it 'returns last 5 events info ordered by creation date descending' do
+        get_feed
+        expect(response.parsed_body).to include_json(
+          events: events.sort_by { |event| -event.created_at.to_i }
+                        .last(5)
+                        .map do |event|
+                          {
+                            content: event.content,
+                            created_at: event.created_at.iso8601(3)
+                          }
+                        end
+        )
+      end
+
+      it 'returns pagination info' do
+        get_feed
+        expect(response.parsed_body).to include_json(
+          pagy: {
+            count: event_count,
+            page: 2,
+            items: 5,
+            pages: 2
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The purpose of this PR is to add the endpoint where the user can see their own activity, even their friends and the friends of them. 
How the activity list could be too large, the answer is limited to 10 activities per request. To achieve it I use the [pagy gem](https://github.com/ddnexus/pagy) which gives the functionality out of the box. 

The steps followed to get the different user level activities were:
1. Get all the user friend's id and the user's id
1. Get all the Friendships filtering by the previous ids. As a result, I obtain all the relationship of the user and their friends.
1. Then, I just retain the `user_id` and `friend_id` of the Friendship table. As a result, I obtain the ids of the user between the current user and the friendship second level. That I called `contacts`.
1. Finally, I query the Event table by the contact's id.