### PR TITLE
Manage user account

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -18,7 +18,9 @@ detectors:
     min_clump_size: 2
   DuplicateMethodCall:
     enabled: true
-    exclude: []
+    exclude: [
+      'AccountManagerService#decrease_account!'
+    ]
     max_calls: 1
     allow_calls: []
   FeatureEnvy:

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: accounts
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  balance    :float            default("0.0"), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Account < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,8 +26,12 @@ class User < ApplicationRecord
            dependent: :nullify,
            inverse_of: :sender
 
+  has_one :account, dependent: :destroy
+
   validates :name, presence: true
   validates :email, presence: true, uniqueness: { case_sensitive: false }
+
+  after_create :create_account
 
   def friends
     incoming_friends + outgoing_friends
@@ -40,5 +44,11 @@ class User < ApplicationRecord
               .pluck(:user_id, :friend_id)
               .flatten
               .uniq
+  end
+
+  private
+
+  def create_account
+    Account.create!(user: self)
   end
 end

--- a/app/services/account_manager_service.rb
+++ b/app/services/account_manager_service.rb
@@ -1,0 +1,32 @@
+class AccountManagerService
+  attr_reader :user, :account, :money_transfer_service
+
+  def initialize(user)
+    @user = user
+    @account = user.account
+    mock_external_service = Object.new
+    @money_transfer_service = MoneyTransferService.new(mock_external_service, self)
+  end
+
+  def increase_account!(amount)
+    return unless amount.positive?
+
+    account.balance += amount
+    account.save!
+  end
+
+  def decrease_account!(amount)
+    return unless amount.positive?
+
+    diff = account.balance - amount
+
+    if diff.negative?
+      money_transfer_service.transfer(diff.abs)
+      account.balance = 0
+    else
+      account.balance -= amount
+    end
+
+    account.save!
+  end
+end

--- a/app/services/money_transfer_service.rb
+++ b/app/services/money_transfer_service.rb
@@ -1,0 +1,14 @@
+class MoneyTransferService
+  attr_reader :external_payment_source, :user_payment_account
+
+  def initialize(external_payment_source, user_payment_account)
+    @external_payment_source = external_payment_source
+    @user_payment_account = user_payment_account
+  end
+
+  def transfer(amount)
+    external_payment_source.try(:send_money, amount)
+    user_payment_account.try(:increase_account, amount)
+    true
+  end
+end

--- a/db/migrate/20201009161123_create_accounts.rb
+++ b/db/migrate/20201009161123_create_accounts.rb
@@ -1,0 +1,9 @@
+class CreateAccounts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :accounts do |t|
+      t.belongs_to :user
+      t.float :balance, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_034950) do
+ActiveRecord::Schema.define(version: 2020_10_09_161123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "accounts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.float "balance", default: 0.0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_accounts_on_user_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.bigint "user_id"

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: accounts
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  balance    :float            default("0.0"), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :account do
+    user
+    balance { 0 }
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: accounts
+#
+#  id         :integer          not null, primary key
+#  user_id    :integer
+#  balance    :float            default("0.0"), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Account, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe User, type: :model do
                                               .dependent(:nullify)
                                               .inverse_of(:sender)
     }
+    it { is_expected.to have_one(:account) }
   end
 
   describe '#friends' do

--- a/spec/requests/api/v1/users/create_spec.rb
+++ b/spec/requests/api/v1/users/create_spec.rb
@@ -16,6 +16,10 @@ describe 'POST /api/v1/users', type: :request do
       expect { create_user }.to change(User, :count).by(1)
     end
 
+    it 'creates the user account' do
+      expect { create_user }.to change(Account, :count).by(1)
+    end
+
     it 'returns the new user info' do
       create_user
       expect(response.parsed_body).to include_json(
@@ -42,6 +46,10 @@ describe 'POST /api/v1/users', type: :request do
         expect { create_user }.not_to change(User, :count)
       end
 
+      it 'does not create the user account' do
+        expect { create_user }.not_to change(Account, :count)
+      end
+
       it 'returns an error message' do
         create_user
         expect(response.parsed_body).to include_json(
@@ -60,6 +68,10 @@ describe 'POST /api/v1/users', type: :request do
 
       it 'does not create a new user' do
         expect { create_user }.not_to change(User, :count)
+      end
+
+      it 'does not create the user account' do
+        expect { create_user }.not_to change(Account, :count)
       end
 
       it 'returns an error message' do
@@ -83,6 +95,10 @@ describe 'POST /api/v1/users', type: :request do
 
       it 'does not create a new user' do
         expect { create_user }.not_to change(User, :count)
+      end
+
+      it 'does not create the user account' do
+        expect { create_user }.not_to change(Account, :count)
       end
 
       it 'returns an error message' do
@@ -111,6 +127,10 @@ describe 'POST /api/v1/users', type: :request do
 
       it 'does not create a new user' do
         expect { create_user }.not_to change(User, :count)
+      end
+
+      it 'does not create the user account' do
+        expect { create_user }.not_to change(Account, :count)
       end
 
       it 'returns an error message' do

--- a/spec/services/account_manager_service_spec.rb
+++ b/spec/services/account_manager_service_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe AccountManagerService do
+  let!(:user) { create(:user) }
+
+  describe '#increase_account!' do
+    subject { described_class.new(user).increase_account!(amount) }
+
+    context 'when the amount is positive' do
+      let(:amount) { Faker::Number.decimal(l_digits: 2) }
+
+      it 'increases the user account balane' do
+        expect { subject }.to change { user.account.reload.balance }.by(amount)
+      end
+    end
+
+    context 'when the amount is 0' do
+      let(:amount) { 0 }
+
+      it 'does not increases the user account balane' do
+        expect { subject }.not_to change { user.account.reload.balance }
+      end
+    end
+
+    context 'when the amount is negative' do
+      let(:amount) { -Faker::Number.decimal(l_digits: 2) }
+
+      it 'does not increases the user account balane' do
+        expect { subject }.not_to change { user.account.reload.balance }
+      end
+    end
+  end
+
+  describe '#decrease_account!' do
+    subject { described_class.new(user).decrease_account!(amount) }
+
+    context 'when the amount is positive' do
+      let(:amount) { Faker::Number.decimal(l_digits: 2) }
+
+      context 'when the amount is less than the user account balance' do
+        let(:initial_balance) { amount * 2 }
+
+        before do
+          user.account.update!(balance: initial_balance)
+        end
+
+        it 'decreases the user account balane' do
+          expect { subject }.to change { user.account.reload.balance }.by(-amount)
+        end
+
+        it 'does not call to an external money service' do
+          expect_any_instance_of(MoneyTransferService).not_to receive(:transfer)
+          subject
+        end
+      end
+
+      context 'when the amount is equals to the user account balance' do
+        let(:initial_balance) { amount }
+
+        before do
+          user.account.update!(balance: initial_balance)
+        end
+
+        it 'decreases the user account balane til 0' do
+          expect { subject }.to change { user.account.reload.balance }.to(0)
+        end
+
+        it 'does not call to an external money service' do
+          expect_any_instance_of(MoneyTransferService).not_to receive(:transfer)
+          subject
+        end
+      end
+
+      context 'when the amount is greater than the user account balance' do
+        let(:initial_balance) { Faker::Number.between(from: 1, to: (amount - 1)) }
+
+        before do
+          user.account.update!(balance: initial_balance)
+        end
+
+        it 'decreases the user account balane til 0' do
+          expect { subject }.to change { user.account.reload.balance }.to(0)
+        end
+
+        it 'calls to an external money service to get the remaining money' do
+          diff = amount - initial_balance
+          expect_any_instance_of(MoneyTransferService).to receive(:transfer).with(diff)
+          subject
+        end
+      end
+    end
+
+    context 'when the amount is 0' do
+      let(:amount) { 0 }
+
+      it 'does not increases the user account balane' do
+        expect { subject }.not_to change { user.account.reload.balance }
+      end
+    end
+
+    context 'when the amount is negative' do
+      let(:amount) { -Faker::Number.decimal(l_digits: 2) }
+
+      it 'does not increases the user account balane' do
+        expect { subject }.not_to change { user.account.reload.balance }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the concept of *Account*. An account is responsible to know how much money a user has on the platform. The relation between users and account is single, so, the users add a `has_one` association to their model. Regarding the accounts existence is mandatory for each user, it's created by a `callback` to ensure the creation as soon as the user was created. So, the user is responsible for creates their own account.

I create the `AccountManagerService` which will be in charge of any operations related to users' money. Also, it encapsulates other operations, like request many to external providers, to give other services only one interface to interact. For example, when the `PaymentCreationService` is creating a payment, it calls the `AccountManagerService` to increase or decrease the money but it doesn't care how the money was made.

Finally, the `MoneyTransferService` service is the suggested mock service to emulate the calls to an external money provider.